### PR TITLE
Drop `repr(u32)` from SyntaxKind

### DIFF
--- a/src/syntax_kinds.rs
+++ b/src/syntax_kinds.rs
@@ -5,7 +5,6 @@ use tree::SyntaxInfo;
 
 /// The kind of syntax node, e.g. `IDENT`, `USE_KW`, or `STRUCT_DEF`.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u32)]
 pub enum SyntaxKind {
     USE_KW,
     FN_KW,


### PR DESCRIPTION
Nomicon says it disables some optimizations:
https://doc.rust-lang.org/beta/nomicon/other-reprs.html#repru-repri