### PR TITLE
Add trivial fuzzer for parser

### DIFF
--- a/crates/libsyntax2/fuzz/.gitignore
+++ b/crates/libsyntax2/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/crates/libsyntax2/fuzz/Cargo.toml
+++ b/crates/libsyntax2/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "libsyntax2-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.libsyntax2]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parser"
+path = "fuzz_targets/parser.rs"

--- a/crates/libsyntax2/fuzz/fuzz_targets/parser.rs
+++ b/crates/libsyntax2/fuzz/fuzz_targets/parser.rs
@@ -1,0 +1,12 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate libsyntax2;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let x = libsyntax2::File::parse(text);
+        let _ = x.ast();
+        let _ = x.syntax();
+        let _ = x.errors();
+    }
+});


### PR DESCRIPTION
As described in #61, fuzz testing some parts of this would be ~~fun~~
helpful. So, I started with the most trivial fuzzer I could think of:
Put random stuff into File::parse and see what happens.

To speed things up, I also did

    cp src/**/*.rs fuzz/corpus/parser/

in the `crates/libsyntax2/` directory (running the fuzzer once will
generate the necessary directories).